### PR TITLE
Allow for optional installation steps

### DIFF
--- a/mpinstaller/installer.py
+++ b/mpinstaller/installer.py
@@ -50,6 +50,7 @@ class MockVersionDependency(object):
     def __init__(self, dependency):
         self.requires = dependency['package_version']
         self.order = dependency['order']
+        self.option_type = dependency['option_type']
     
 def create_repo_package_versions(version, git_ref=None, fork=None):
     """ Creates all dependent PackageVersion objects from a PackageVersion with a repo_url """
@@ -162,6 +163,7 @@ def create_repo_package_versions(version, git_ref=None, fork=None):
                     'subfolder': '%s/%s' % (subfolder, bundle),
                     'branch': version.branch,
                     'order': counter_pre,
+                    'option_type': 'default',
                 })
 
         # Handle the namespace package
@@ -171,6 +173,7 @@ def create_repo_package_versions(version, git_ref=None, fork=None):
             'name': version_number,
             'number': version_number,
             'order': counter_pre,
+            'option_type': 'default',
         })
 
         # Handle post bundles for the namespace
@@ -186,6 +189,7 @@ def create_repo_package_versions(version, git_ref=None, fork=None):
                     'subfolder': '%s/%s' % (subfolder, bundle),
                     'branch': version.branch,
                     'order': counter_pre,
+                    'option_type': 'default',
                 })
 
         counter_pre += 1
@@ -200,6 +204,7 @@ def create_repo_package_versions(version, git_ref=None, fork=None):
                 'subfolder': subfolder,
                 'branch': version.branch,
                 'order': counter_pre,
+                'option_type': 'default',
             })
             counter_pre += 1
 
@@ -214,6 +219,7 @@ def create_repo_package_versions(version, git_ref=None, fork=None):
                 'subfolder': subfolder,
                 'branch': version.branch,
                 'order': counter_post,
+                'option_type': 'optional',
             })
             counter_post += 1
     
@@ -303,12 +309,14 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
         if dependency.order < 100:
             packages.append({
                 'version': dependency.requires,
+                'option_type': dependency.option_type,
                 'installed': installed_version,
                 'action': 'uninstall',
             })
         else:
             packages_post.append({
                 'version': dependency.requires,
+                'option_type': dependency.option_type,
                 'installed': installed_version,
                 'action': 'uninstall',
             })
@@ -332,6 +340,7 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
     if uninstall:
         packages.append({
             'version': version,
+            'option_type': 'required',
             'installed': installed_version,
             'action': 'uninstall',
         })
@@ -364,12 +373,14 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
                 if dependency.order < 100:
                     packages.append({
                         'version': dependency.requires,
+                        'option_type': dependency.option_type,
                         'installed': installed_version,
                         'action': 'skip',
                     })
                 else:
                     packages_post.append({
                         'version': dependency.requires,
+                        'option_type': dependency.option_type,
                         'installed': installed_version,
                         'action': 'skip',
                     })
@@ -378,12 +389,14 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
         if dependency.order < 100:
             packages.append({
                 'version': dependency.requires,
+                'option_type': dependency.option_type,
                 'installed': installed_version,
                 'action': 'install',
             })
         else:
             packages_post.append({
                 'version': dependency.requires,
+                'option_type': dependency.option_type,
                 'installed': installed_version,
                 'action': 'install',
             })
@@ -401,6 +414,7 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
         if installed_version != version.number:
             packages.append({
                 'version': version,
+                'option_type': 'required',
                 'installed': installed_version,
                 'action': 'install',
             })
@@ -408,6 +422,7 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
         elif not version.number:
             packages.append({
                 'version': version,
+                'option_type': 'required',
                 'installed': installed_version,
                 'action': 'install',
             })
@@ -415,12 +430,14 @@ def version_install_map(version, installed=None, metadata=None, git_ref=None, fo
         else:
             packages.append({
                 'version': version,
+                'option_type': 'required',
                 'installed': installed_version,
                 'action': 'skip',
             })
     else:
         packages.append({
             'version': version,
+            'option_type': 'required',
             'installed': installed_version,
             'action': 'skip',
         })
@@ -453,9 +470,11 @@ def install_map_to_package_list(install_map):
                 'upgrade': False,
                 'uninstall': False,
                 'skip': False,
+                'default_checked': True,
                 'namespace': package.namespace,
                 'installed': step['installed'],
                 'version': step['version'],
+                'option_type': step['option_type'],
             }
 
         # Set the install, upgrade, uninstall, and skip values
@@ -470,6 +489,7 @@ def install_map_to_package_list(install_map):
 
         if not namespaces[package.namespace]['uninstall'] and not namespaces[package.namespace]['install'] and not namespaces[package.namespace]['upgrade']:
             namespaces[package.namespace]['skip'] = True
+            namespaces[package.namespace]['default_checked'] = False
 
     # Convert the dictionary into an ordered list for use in templates.
     namespaces_list = []

--- a/mpinstaller/migrations/0031_auto__add_field_packageversiondependency_option_type.py
+++ b/mpinstaller/migrations/0031_auto__add_field_packageversiondependency_option_type.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'PackageVersionDependency.option_type'
+        db.add_column(u'mpinstaller_packageversiondependency', 'option_type',
+                      self.gf('django.db.models.fields.CharField')(default='required', max_length=32),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'PackageVersionDependency.option_type'
+        db.delete_column(u'mpinstaller_packageversiondependency', 'option_type')
+
+
+    models = {
+        u'mpinstaller.actioneditpicklist': {
+            'Meta': {'object_name': 'ActionEditPicklist', '_ormbases': [u'mpinstaller.OrgAction']},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'custom_field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'custom_object': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'orgaction_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mpinstaller.OrgAction']", 'unique': 'True', 'primary_key': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'mpinstaller.actioneditstagename': {
+            'Meta': {'object_name': 'ActionEditStageName', '_ormbases': [u'mpinstaller.OrgAction']},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            'closed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'custom_field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'custom_object': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'forecast_category': ('django.db.models.fields.CharField', [], {'max_length': '16'}),
+            u'orgaction_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['mpinstaller.OrgAction']", 'unique': 'True', 'primary_key': 'True'}),
+            'probability': ('django.db.models.fields.IntegerField', [], {}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'won': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'mpinstaller.installationerror': {
+            'Meta': {'object_name': 'InstallationError'},
+            'content': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'errors'", 'null': 'True', 'to': u"orm['mpinstaller.InstallationErrorContent']"}),
+            'fallback_content': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'errors_fallback'", 'null': 'True', 'to': u"orm['mpinstaller.InstallationErrorContent']"}),
+            'hide_from_report': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {})
+        },
+        u'mpinstaller.installationerrorcontent': {
+            'Meta': {'object_name': 'InstallationErrorContent'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'resolution': ('tinymce.models.HTMLField', [], {})
+        },
+        u'mpinstaller.metadatacondition': {
+            'Meta': {'object_name': 'MetadataCondition'},
+            'exclude_namespaces': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'metadata_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'no_match': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'search': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'mpinstaller.orgaction': {
+            'Meta': {'object_name': 'OrgAction'},
+            'content_failure': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_intro': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_success': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'force_sandbox': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        u'mpinstaller.package': {
+            'Meta': {'ordering': "['namespace']", 'object_name': 'Package'},
+            'content_failure': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_failure_beta': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_intro': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_intro_beta': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_success': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_success_beta': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'current_beta': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'current_beta'", 'null': 'True', 'to': u"orm['mpinstaller.PackageVersion']"}),
+            'current_github': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'current_github'", 'null': 'True', 'to': u"orm['mpinstaller.PackageVersion']"}),
+            'current_prod': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'current_prod'", 'null': 'True', 'to': u"orm['mpinstaller.PackageVersion']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'force_sandbox': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'namespace': ('django.db.models.fields.SlugField', [], {'max_length': '128'})
+        },
+        u'mpinstaller.packageinstallation': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'PackageInstallation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'fork': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'git_ref': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'install_map': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'instance_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'log': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'org_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'org_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'installations'", 'to': u"orm['mpinstaller.Package']"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'version': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'installations'", 'null': 'True', 'to': u"orm['mpinstaller.PackageVersion']"})
+        },
+        u'mpinstaller.packageinstallationsession': {
+            'Meta': {'object_name': 'PackageInstallationSession'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'installation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sessions'", 'to': u"orm['mpinstaller.PackageInstallation']"}),
+            'metadata': ('django.db.models.fields.TextField', [], {}),
+            'oauth': ('django.db.models.fields.TextField', [], {}),
+            'org_packages': ('django.db.models.fields.TextField', [], {})
+        },
+        u'mpinstaller.packageinstallationstep': {
+            'Meta': {'ordering': "['-installation__id', 'order']", 'object_name': 'PackageInstallationStep'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'error': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'steps'", 'null': 'True', 'to': u"orm['mpinstaller.InstallationError']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'installation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'steps'", 'to': u"orm['mpinstaller.PackageInstallation']"}),
+            'log': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'installation_steps'", 'null': 'True', 'to': u"orm['mpinstaller.Package']"}),
+            'previous_version': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'version': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'installation_steps'", 'null': 'True', 'to': u"orm['mpinstaller.PackageVersion']"})
+        },
+        u'mpinstaller.packageversion': {
+            'Meta': {'ordering': "['package__namespace', 'number']", 'object_name': 'PackageVersion'},
+            'branch': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'conditions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['mpinstaller.MetadataCondition']", 'null': 'True', 'blank': 'True'}),
+            'content_failure': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_intro': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'content_success': ('tinymce.models.HTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'github_password': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'github_username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'namespace_token': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'package': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'versions'", 'to': u"orm['mpinstaller.Package']"}),
+            'package_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'repo_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'subfolder': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'zip_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'mpinstaller.packageversiondependency': {
+            'Meta': {'ordering': "['order']", 'object_name': 'PackageVersionDependency'},
+            'action': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'required_by'", 'null': 'True', 'to': u"orm['mpinstaller.OrgAction']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'option_type': ('django.db.models.fields.CharField', [], {'default': "'required'", 'max_length': '32'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'requires': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'required_by'", 'null': 'True', 'to': u"orm['mpinstaller.PackageVersion']"}),
+            'version': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'dependencies'", 'to': u"orm['mpinstaller.PackageVersion']"})
+        }
+    }
+
+    complete_apps = ['mpinstaller']

--- a/mpinstaller/models.py
+++ b/mpinstaller/models.py
@@ -356,10 +356,17 @@ class PackageVersion(models.Model):
     class Meta:
         ordering = ['package__namespace','number']
 
+OPTION_TYPE_CHOICES = (
+    ('required', 'Required'),
+    ('default', 'Default'),
+    ('optional', 'Optional'),
+)
+
 class PackageVersionDependency(models.Model):
     version = models.ForeignKey(PackageVersion, related_name='dependencies')
     requires = models.ForeignKey(PackageVersion, related_name='required_by', null=True, blank=True)
     action = models.ForeignKey(OrgAction, related_name='required_by', null=True, blank=True)
+    option_type = models.CharField(choices=OPTION_TYPE_CHOICES, default='required', max_length=32)
     order = models.IntegerField()
 
     def __unicode__(self):

--- a/mpinstaller/templates/mpinstaller/package_version_overview.html
+++ b/mpinstaller/templates/mpinstaller/package_version_overview.html
@@ -103,6 +103,9 @@
       </div>
      
       <div class="panel-body"> 
+        <form id="installation_overview_form" method="GET" action="{{ install_url }}">
+        {% if fork %}<input type="hidden" name="fork" value="{{ fork }}" />{% endif %}
+        {% if git_ref %}<input type="hidden" name="git_ref" value="{{ git_ref }}" />{% endif %}
         <p>{{ version.package }} {{ version.number }} requires the following bundles and packages:</p>
         <ul class="list-group">
           {% for step in package_list %}
@@ -110,6 +113,11 @@
             <div class="row">
               <div class="col-md-7">
                 <h4 class="list-group-item-heading">
+                  {% if step.option_type == 'required' %}
+                  <input type="hidden" name="steps" value="{{ step.version.package.namespace }}" />
+                  {% else %}
+                  <input class="installation-step-checkbox" type="checkbox" name="steps" {% if step.option_type == 'default' %}checked="checked"{% endif %} value="{{ step.version.package.namespace }}" />
+                  {% endif %}
                   {{ step.version.package.name }}
                   {% if step.version.number %}
                     <span class="text-muted">- {{ step.version.number }}
@@ -132,16 +140,16 @@
 
               <div class="col-md-2">
                 {% if step.uninstall %}
-                <div class="text-warning"><span class="glyphicon glyphicon-cloud-download"></span> Uninstall</span></div>
+                <div class="text-warning installation-action-uninstall"><span class="glyphicon glyphicon-cloud-download"></span> Uninstall</span></div>
                 {% endif %}
                 {% if step.install %}
-                <div class="text-primary"><span class="glyphicon glyphicon-cloud-upload"></span> Install</span></div>
+                <div class="text-primary installation-action-upload"><span class="glyphicon glyphicon-cloud-upload"></span> Install</span></div>
                 {% endif %}
                 {% if step.upgrade %}
-                <div class="text-info"><span class="glyphicon glyphicon-cloud-upload"></span> Upgrade from {{ step.installed }}</span></div>
+                <div class="text-info installation-action-upgrade"><span class="glyphicon glyphicon-cloud-upload"></span> Upgrade from {{ step.installed }}</span></div>
                 {% endif %}
                 {% if step.skip %}
-                <div class="text-muted"><span class="glyphicon glyphicon-ok"></span> No change</span></div>
+                <div class="text-muted installation-action-skip{% if not step.skip %}{% endif %}"><span class="glyphicon glyphicon-ok"></span> No change</span></div>
                 {% endif %}
               </div>
             </div>
@@ -150,7 +158,7 @@
         </ul>
     
         <div class="btn-group">
-          <a class="btn btn-info" data-toggle="modal" data-target=".install-confirm-modal"><span class="glyphicon glyphicon-cloud-upload"></span> Install</a>
+          <button type="submit" class="btn btn-info" data-toggle="modal" data-target=".install-confirm-modal"><span class="glyphicon glyphicon-cloud-upload"></span> Install</button>
         </div>
       </div>
     </div>
@@ -181,13 +189,6 @@
       {% endif %}
       {% endfor %}
 
-      <div class="alert alert-info">
-        <h4>Verify your organization</h4>
-        <p>Please re-type the Salesforce username you used for the initial connection. We want to make sure that you're installing {{ version.package }} in the right org!</p>
-        <strong>Connected as: {{ oauth.username }}</strong>
-        <p><input type="text" id="verify-org-username" /></p>
-      </div>
-
       <button type="button" class="btn btn-primary" id="confirm-install-button">Install</button>
       <script type="text/javascript">
         {% autoescape off %}
@@ -198,13 +199,17 @@
                 alert('Please check all confirm boxes on all warnings to continue');
                 return false;
             }
-
-            if ($('#verify-org-username').val() != $('#oauth-username').text()) {
-                alert('Username did not match your connected org.  Please retype your username to continue.');
-                return false;
-            }
-            window.location = '{{ install_url }}'
-            
+            $('#installation_overview_form').submit();
+        });
+        $('input.installation-step-checkbox').each(function () {
+            $(this).click(function () {
+                checkbox = $(this)
+                if (this.checked == true) {
+                    checkbox.closest('.list-group-item').addClass('list-group-item-success');    
+                } else {
+                    checkbox.closest('.list-group-item').removeClass('list-group-item-success');    
+                }
+            });
         });
         {% endautoescape %}
       </script>


### PR DESCRIPTION
PackageVersionDependencies now have a new field, option type, which can set them as Optional (unchecked by default), Default (checked by default), or Required (always installed).  This allows some steps to be bypassed and for optional extra metadata to be deployed if selected by the user.
